### PR TITLE
Workaround for BBB 2.6: Convert new .svg slides to .png before rendering

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-alpine
-RUN apk add --no-cache chromium ffmpeg
+RUN apk add --no-cache chromium ffmpeg inkscape
 RUN adduser -D bigbluebutton bigbluebutton
 USER bigbluebutton
 WORKDIR /home/bigbluebutton

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -12,6 +12,7 @@ parser.add_argument('-v', '--version', { action: 'version', version })
 parser.add_argument('-i', '--input', { help: 'path to BigBlueButton published presentation', required: true })
 parser.add_argument('-o', '--output', { help: 'path to outfile', required: true })
 parser.add_argument('-c', '--copy', { action: 'store_true', help: 'create a temporary copy of the presentation directory before working on it' })
+parser.add_argument('-p', '--png', { action: 'store_true', help: 'workaround for BBB 2.6: convert svg slides to png before rendering' })
 parser.add_argument('-t', '--threads', { help: 'number of threads to use for ffmpeg calls', default: 1 })
 
 const arguments = parser.parse_args()

--- a/src/modules/slides.js
+++ b/src/modules/slides.js
@@ -38,7 +38,7 @@ const convertSlidesToPng = async (basedir) => {
             if (file.name.endsWith('.svg') && file.isFile()) {
                 const svgfilepath = svgspath + '/' + file.name
                 const pngfilepath = svgspath + '/' + file.name + '.png'
-                childProcess.execSync(`convert ${svgfilepath} ${pngfilepath}`)
+                childProcess.execSync(`convert -density 144 ${svgfilepath} ${pngfilepath}`)
             }
         }
         directory.closeSync()

--- a/src/modules/slides.js
+++ b/src/modules/slides.js
@@ -7,6 +7,7 @@ const { parseStringPromise } = require('xml2js')
 const { parseNumbers } = require('xml2js/lib/processors')
 
 module.exports.renderSlides = async (config, duration) => {
+    await convertSlidesToPng(config.args.input)
     const presentation = await parseSlidesData(config.args.input, duration)
     if (Object.keys(presentation.frames).length > 1) {
         await createFrames(config, presentation)
@@ -14,6 +15,27 @@ module.exports.renderSlides = async (config, duration) => {
         return presentation
     }
     return null
+}
+
+const convertSlidesToPng = async (basedir) => {
+    const pres_dirs = fs.readdirSync(basedir + 'presentation/').filter(function (file) {
+        return fs.statSync(basedir + 'presentation/' + file).isDirectory();
+    });
+    console.log(pres_dirs)
+    const svgspath = basedir + '/presentation/' + pres_dirs[0] + '/svgs'
+    console.log(svgspath)
+
+    if (fs.existsSync(svgspath)) {
+        const directory = fs.opendirSync(svgspath)
+        let file
+        while ((file = directory.readSync()) !== null) {
+            console.log(file.name)
+            const svgfilepath = svgspath + '/' + file.name
+            const pngfilepath = svgspath + '/' + file.name + '.png'
+            childProcess.execSync(`inkscape ${svgfilepath} --export-type=png --export-filename=${pngfilepath} --export-dpi 384`)
+        }
+        directory.closeSync()
+    }
 }
 
 const actions = {


### PR DESCRIPTION
This PR introduces an option to convert .svg slide files (as they are now in BBB 2.6 recordings) to .png files before rendering. Imagemagick convert is used for the conversion.

The new .svgs slide files of BBB 2.6 recordings do not load in the chromium used by puppeteer and therefore the final video does not contain the presentation (but a placeholder image instead). Despite a lot of effort and research I was not able to fix this issue. So this workaround is the only solution I was able to to come up with to make the bbb-video-download extension functional for BBB 2.6.

The option can be enabled with the argument -p or --png . It is advised to use it in conjunction with the option to copy the data directory to the temporary working directory before rendering (-c or --copy), which is also a new option introduced by me before developing this workaround (although without explaining it in a PR).