### PR TITLE
Install inkscape for better svg support

### DIFF
--- a/snippets/bbb27_ruby27_post_publish_bbb_video_download.rb.template
+++ b/snippets/bbb27_ruby27_post_publish_bbb_video_download.rb.template
@@ -1,0 +1,59 @@
+#!/usr/bin/ruby
+# encoding: UTF-8
+
+#
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3.0 of the License, or (at your option)
+# any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+#
+
+require "optparse"
+require File.expand_path('../../../lib/recordandplayback', __FILE__)
+
+meeting_id = nil
+OptionParser.new do |opts|
+  opts.on('-m', '--meeting-id MEETING_ID', 'Internal Meeting ID') do |v|
+    meeting_id = v
+  end
+  opts.on('-f', '--format FORMAT', 'Recording Format') do |v|
+  end
+end.parse!
+
+logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly' )
+logger.level = Logger::INFO
+BigBlueButton.logger = logger
+
+published_files = "/var/bigbluebutton/published/presentation/#{meeting_id}"
+meeting_metadata = BigBlueButton::Events.get_meeting_metadata("/var/bigbluebutton/recording/raw/#{meeting_id}/events.xml")
+
+#
+### Main Code
+#
+
+require 'shellwords'
+input_dir = Shellwords.escape(published_files)
+output_file = Shellwords.escape("#{published_files}/video.mp4")
+base_dir = '${BBB_VIDEO_DOWNLOAD_DIR}'
+
+BigBlueButton.logger.info("Create downloadable video for [#{meeting_id}] start")
+
+rs = "cd #{base_dir} && docker-compose run --rm --user ${BBB_UID}:${BBB_GID} app node index.js -i #{input_dir} -o #{output_file} -p"
+system(rs) # run shell script in Ruby 2.7
+
+BigBlueButton.logger.info(rs)
+BigBlueButton.logger.info("Create downloadable video for [#{meeting_id}] end")
+
+exit 0

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-alpine
-RUN apk add --no-cache chromium ffmpeg imagemagick
+RUN apk add --no-cache chromium ffmpeg imagemagick inkscape
 
 RUN adduser -D bigbluebutton bigbluebutton
 USER bigbluebutton


### PR DESCRIPTION
We had issues with the conversion of our slides with BBB 2.7.
Even with using '-p' imagemagick was not able to convert the slides to png.

I was able to reproduce the conversion issues on my machine too and fter reading https://github.com/ImageMagick/ImageMagick/discussions/2033 i just installed inkscape to fix it.

By adding inkscape to the container imagemagick seems to be more robust with the current svgs.

This finally fixed our issues with the slides :)